### PR TITLE
get thin record for 'us.com' domains first, then query for full record (adds support for '.us.com')

### DIFF
--- a/pythonwhois/net.py
+++ b/pythonwhois/net.py
@@ -12,7 +12,9 @@ def get_whois_raw(domain, server="", previous=None, rfc3490=True, never_cut=Fals
 		".buzz": "whois.nic.buzz",
 		".moe": "whois.nic.moe",
 		# The following is a bit hacky, but IANA won't return the right answer for example.com because it's a direct registration.
-		"example.com": "whois.verisign-grs.com"
+		"example.com": "whois.verisign-grs.com",
+		# Query 'whois.centralnic.net' for 'us.com' for thin record, then query specific server for full record
+		"us.com": "whois.centralnic.net"
 	}
 	
 	if rfc3490:


### PR DESCRIPTION
@gmicek-liongard This is intended to add support for `.us.com` domains. 

With this change, we'll query `whois.centralnic.net` for a 'thin' record for any `.us.com` domains. Once we have the 'thin' record, we'll query the specified registrar WHOIS server to get the full record (see: https://github.com/liongard/python-whois/blob/master/pythonwhois/net.py#L63-L69).