### PR TITLE
fix escaping in regular expression to resolve issue w/ python 3.7+

### DIFF
--- a/pythonwhois/parse.py
+++ b/pythonwhois/parse.py
@@ -202,7 +202,7 @@ grammar = {
 
 def preprocess_regex(regex):
 	# Fix for #2; prevents a ridiculous amount of varying size permutations.
-	regex = re.sub(r"\\s\*\(\?P<([^>]+)>\.\+\)", r"\s*(?P<\1>\S.*)", regex)
+	regex = re.sub(r"\\s\*\(\?P<([^>]+)>\.\+\)", r"\\s*(?P<\1>\\S.*)", regex)
 	# Experimental fix for #18; removes unnecessary variable-size whitespace
 	# matching, since we're stripping results anyway.
 	regex = re.sub(r"\[ \]\*\(\?P<([^>]+)>\.\*\)", r"(?P<\1>.*)", regex)


### PR DESCRIPTION
In newer versions of python (like 3.7 and above), `python-whois` runs into an escaping issue for one of its regular expressions, e.g.

`❯ python get_whois.py google.com
Traceback (most recent call last):
  File "/Users/colemujadzic/.pyenv/versions/3.8.2/lib/python3.8/sre_parse.py", line 1039, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\s'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "get_whois.py", line 11, in <module>
    import pythonwhois
  File "/Users/colemujadzic/code/liongard-github/python-whois/pythonwhois/__init__.py", line 1, in <module>
    from . import net, parse
  File "/Users/colemujadzic/code/liongard-github/python-whois/pythonwhois/parse.py", line 363, in <module>
    registrant_regexes = [preprocess_regex(regex) for regex in registrant_regexes]
  File "/Users/colemujadzic/code/liongard-github/python-whois/pythonwhois/parse.py", line 363, in <listcomp>
    registrant_regexes = [preprocess_regex(regex) for regex in registrant_regexes]
  File "/Users/colemujadzic/code/liongard-github/python-whois/pythonwhois/parse.py", line 205, in preprocess_regex
    regex = re.sub(r"\\s\*\(\?P<([^>]+)>\.\+\)", r"\s*(?P<\1>\S.*)", regex)
  File "/Users/colemujadzic/.pyenv/versions/3.8.2/lib/python3.8/re.py", line 208, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/Users/colemujadzic/.pyenv/versions/3.8.2/lib/python3.8/re.py", line 325, in _subx
    template = _compile_repl(template, pattern)
  File "/Users/colemujadzic/.pyenv/versions/3.8.2/lib/python3.8/re.py", line 316, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/Users/colemujadzic/.pyenv/versions/3.8.2/lib/python3.8/sre_parse.py", line 1042, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \s at position 0`

This just adds additional backslashes to ensure the whitespace is properly escaped.