### PR TITLE
wrap match access with try / catch to avoid index out of range error

### DIFF
--- a/pythonwhois/parse.py
+++ b/pythonwhois/parse.py
@@ -518,7 +518,10 @@ def parse_raw_whois(raw_data, normalized=None, never_query_handles=True, handle_
 		if match is not None:
 			chunk = match.group(1)
 			for match in re.findall("\s+?(.+)\n", chunk):
-				match = match.split()[0]
+				try:
+					match = match.split()[0]
+				except IndexError:
+					match = "[]"
 				# Prevent nameserver aliases from being picked up.
 				if not match.startswith("[") and not match.endswith("]"):
 					try:


### PR DESCRIPTION
This is derived from @chb2mn's linked commit on https://github.com/joepie91/python-whois/issues/90 and resolves an issue common for lookups against `.gg` domains